### PR TITLE
Static widget docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 stages:
   - "Static code analysis"
   - test
-  - deploy
+  - "Build and deploy"
 notifications:
   email: false
 python:
@@ -45,12 +45,20 @@ jobs:
       python: "3.7"
       install:
         - pip install -qq mypy
-    - stage: deploy
-      name: "Deploy to pypi"
+    - stage: "Build and deploy"
+      if: tag IS NOT present
+      name: "test flit build"
+      python: "3.7"
+      install:
+        - pip install flit
+      script:
+        - flit build
+    - stage: "Build and deploy"
+      name: "build & deploy to pypi"
+      python: "3.7"
       if: tag IS present
       install:
         - pip install flit
       script:
         - flit build
         - env FLIT_USERNAME=$PYPI_USER FLIT_PASSWORD=$PYPI_PASSWORD flit publish
-      python: "3.7"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,12 +62,11 @@ nbsphinx_prolog = r"""
         :format: html
 
     .. nbinfo::
-        This page was generated from `{{ docname }}`__.
-        Interactive online version:
+        This page was generated from `{{ docname }}`__. All widgets shown here
+        are "static", and interacting with them won't change the rest of the
+        widgets. You can find a fully interactive online version here:
         :raw-html:`<a href="https://mybinder.org/v2/gh/janfreyberg/ipyannotations/{{ env.config.release }}?filepath={{ docname }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>`
 
     __ https://github.com/janfreyberg/ipyannotations/blob/{{ env.config.release }}/{{ docname }}
 
 """
-
-nbsphinx_widgets_path = ""


### PR DESCRIPTION
- added a travis stage that builds the documentation (but doesn't publish) when no tag is present
- added static widget documentation to quick-start (by using the `Image` widget)
