### PR TITLE
Improve the data clearing experience

### DIFF
--- a/src/ipyannotations/images/annotator.py
+++ b/src/ipyannotations/images/annotator.py
@@ -170,7 +170,7 @@ class Annotator(widgets.VBox):
         self.undo_callbacks: List[Callable[[], None]] = []
         self.skip_callbacks: List[Callable[[], None]] = []
 
-        super().__init__()
+        super().__init__(layout={"width": f"{self.canvas.size[0]}px"})
         self.children = [self.canvas, self.all_controls]
 
     def display(self, image: Union[widgets.Image, pathlib.Path]):

--- a/src/ipyannotations/images/canvases/_abstract.py
+++ b/src/ipyannotations/images/canvases/_abstract.py
@@ -55,7 +55,7 @@ class AbstractAnnotationCanvas(MultiCanvas):
         else:
             self.colormap = defaultdict(lambda: "#000000")
 
-        self._init_empty_data()
+        self.init_empty_data()
 
     def load_image(self, image: Union[widgets.Image, str, pathlib.Path]):
         """Display an image on the annotation canvas.
@@ -68,7 +68,7 @@ class AbstractAnnotationCanvas(MultiCanvas):
         image = load_img(image)
         self.current_image = image
         self._display_image()
-        self._init_empty_data()
+        self.init_empty_data()
 
     @observe("current_class")
     def _set_class(self, change):
@@ -99,7 +99,7 @@ class AbstractAnnotationCanvas(MultiCanvas):
         pass
 
     @abc.abstractmethod
-    def _init_empty_data(self):
+    def init_empty_data(self):
         raise NotImplementedError(
             "This canvas does not implement initialising the data."
         )

--- a/src/ipyannotations/images/canvases/_abstract.py
+++ b/src/ipyannotations/images/canvases/_abstract.py
@@ -71,7 +71,7 @@ class AbstractAnnotationCanvas(MultiCanvas):
         self.init_empty_data()
 
     def clear(self) -> None:
-        """Clear the canvas; clearing the image and deleting any annotations."""
+        """Clear the canvas - clear the image and delete any annotations."""
         super().clear()
         self.init_empty_data()
 

--- a/src/ipyannotations/images/canvases/_abstract.py
+++ b/src/ipyannotations/images/canvases/_abstract.py
@@ -25,7 +25,7 @@ class AbstractAnnotationCanvas(MultiCanvas):
         classes: Optional[Sequence[str]] = None,
         **kwargs
     ):
-        super().__init__(n_canvases=3, size=size, **kwargs)
+        super().__init__(n_canvases=3, width=size[0], height=size[1], **kwargs)
         self._undo_queue: Deque[Callable] = deque([])
         self.image_extent = (0, 0, *size)
 
@@ -68,6 +68,11 @@ class AbstractAnnotationCanvas(MultiCanvas):
         image = load_img(image)
         self.current_image = image
         self._display_image()
+        self.init_empty_data()
+
+    def clear(self) -> None:
+        """Clear the canvas; clearing the image and deleting any annotations."""
+        super().clear()
         self.init_empty_data()
 
     @observe("current_class")

--- a/src/ipyannotations/images/canvases/box.py
+++ b/src/ipyannotations/images/canvases/box.py
@@ -116,7 +116,7 @@ class BoundingBoxAnnotationCanvas(AbstractAnnotationCanvas):
     def _undo_new_box(self):
         self.annotations.pop()
 
-    def _init_empty_data(self):
+    def init_empty_data(self):
         self.annotations: List[BoundingBox] = []
         self._undo_queue.clear()
 
@@ -127,7 +127,7 @@ class BoundingBoxAnnotationCanvas(AbstractAnnotationCanvas):
     @data.setter  # type: ignore
     @trigger_redraw
     def data(self, value: List[dict]):
-        self._init_empty_data()
+        self.init_empty_data()
         self.annotations = [
             BoundingBox.from_data(annotation.copy()) for annotation in value
         ]

--- a/src/ipyannotations/images/canvases/point.py
+++ b/src/ipyannotations/images/canvases/point.py
@@ -85,5 +85,5 @@ class PointAnnotationCanvas(AbstractAnnotationCanvas):
             Point.from_data(point_dict.copy()) for point_dict in value
         ]
 
-    def _init_empty_data(self):
+    def init_empty_data(self):
         self.points: List[Point] = []

--- a/src/ipyannotations/images/canvases/polygon.py
+++ b/src/ipyannotations/images/canvases/polygon.py
@@ -149,11 +149,11 @@ class PolygonAnnotationCanvas(AbstractAnnotationCanvas):
     @data.setter  # type: ignore
     @trigger_redraw
     def data(self, value: List[dict]):
-        self._init_empty_data()
+        self.init_empty_data()
         self.polygons = [
             Polygon.from_data(polygon_dict.copy()) for polygon_dict in value
         ]
 
-    def _init_empty_data(self):
+    def init_empty_data(self):
         self.polygons: List[Polygon] = []
         self.current_polygon: Polygon = Polygon(label=self.current_class)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ strategies.coordinates = lambda: coordinates
 
 @strategies.composite
 def polygons(draw):
-    points = strategies.lists(coordinates)
+    points = strategies.lists(coordinates, min_size=3)
     label = strategies.text()
 
     return Polygon(draw(points), draw(label))

--- a/tests/test_abstract_canvas.py
+++ b/tests/test_abstract_canvas.py
@@ -20,7 +20,7 @@ def test_that_loading_image_clears_data(
 ):
 
     with patch.object(
-        AbstractAnnotationCanvas, "_init_empty_data"
+        AbstractAnnotationCanvas, "init_empty_data"
     ) as mock_init_empty_data:
         canvas = AbstractAnnotationCanvas()
         mock_init_empty_data.reset_mock()
@@ -38,7 +38,7 @@ def test_that_loading_image_from_path(img: Image.Image):
         img.save(tmp)
 
         with patch.object(
-            AbstractAnnotationCanvas, "_init_empty_data"
+            AbstractAnnotationCanvas, "init_empty_data"
         ) as mock_init_empty_data:
             canvas = AbstractAnnotationCanvas()
             mock_init_empty_data.reset_mock()
@@ -50,7 +50,7 @@ def test_that_loading_image_from_path(img: Image.Image):
 @given(img=infer)
 def test_that_fit_image_always_fits_image(img: widgets.Image):
 
-    with patch.object(AbstractAnnotationCanvas, "_init_empty_data"):
+    with patch.object(AbstractAnnotationCanvas, "init_empty_data"):
         canvas = AbstractAnnotationCanvas()
 
     x0, y0, x1, y1 = fit_image(img, canvas)

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -83,5 +83,5 @@ def test_changing_brightness(image_array):
     )
 
     assert (new_image_array / image_array).mean() == pytest.approx(
-        1.5, abs=1 / 256
+        1.5, abs=0.01
     )

--- a/tests/test_polygon_canvas.py
+++ b/tests/test_polygon_canvas.py
@@ -126,7 +126,7 @@ def test_editing_mode(polygon: Polygon, polygons: List[Polygon]):
 @given(polygon=infer)
 def test_dragging_without_edit_mode(polygon: Polygon):
 
-    assume(len(polygon) > 4)
+    assume(len(polygon) > 2)
 
     canvas = PolygonAnnotationCanvas()
     canvas.editing = False

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -61,7 +61,8 @@ def test_that_adding_point_close_by_closes(poly: Polygon):
 @given(poly=infer)
 def test_that_polygon_doesnt_close_if_only_two_points(poly: Polygon):
 
-    assume(len(poly.points) == 1)
+    if len(poly.points) > 1:
+        poly.points = poly.points[:1]
 
     start_point = poly.points[0]
     max_dist = poly.close_threshold


### PR DESCRIPTION
This makes two changes:

- the init_empty_data method lost its prefix '_'
- the 'clear' method on canvases now also calls init_empty_data

This fixes #15.

Unrelated change: the canvas was being stretched when the notebook cell output container was wider than the canvas. The size of the widget container is now fixed to the size of the canvas.