### PR TITLE
Use MyST parser, rather than m2r, for markdown

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,10 +1,12 @@
 # API Index
 
-.. contents::
-   :local:
+```{contents}
+:local:
+```
 
 ## Polygon annotations
 
+```{eval-rst}
 .. autoclass:: ipyannotations.PolygonAnnotator
 
    .. rubric:: Methods
@@ -16,9 +18,11 @@
    .. rubric:: Attributes
    .. autoattribute:: options
    .. autoattribute:: data
+```
 
 ## Point annotations
 
+```{eval-rst}
 .. autoclass:: ipyannotations.PointAnnotator
 
    .. rubric:: Methods
@@ -30,9 +34,11 @@
    .. rubric:: Attributes
    .. autoattribute:: options
    .. autoattribute:: data
+```
 
 ## Bounding box annotations
 
+```{eval-rst}
 .. autoclass:: ipyannotations.BoxAnnotator
 
    .. rubric:: Methods
@@ -44,3 +50,4 @@
    .. rubric:: Attributes
    .. autoattribute:: options
    .. autoattribute:: data
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ release = version
 
 master_doc = "index"
 
-extensions = ["m2r", "nbsphinx", "sphinx.ext.napoleon"]
+extensions = ["myst_parser", "nbsphinx", "sphinx.ext.napoleon"]
 
 source_suffix = [".rst", ".md"]
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,14 +9,16 @@ For example, draw polygons onto images for your machine learning applications:
 
 ![interface](img/interface.png)
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+```{toctree}
+---
+maxdepth: 2
+caption: "Contents:"
+---
 
-   installation
-   quick-start
-   api
-
+installation
+quick-start
+api
+```
 
 
 ## Indices and tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,9 @@ dev = [
 ]
 doc = [
     "sphinx>=2.3",
-    "m2r",
     "sphinx_rtd_theme",
     "nbsphinx",
+    "myst-parser>=0.12.9",
 ]
 
 


### PR DESCRIPTION
- m2r does not work for latest sphinx versions
- myst is a new parser that introduces new markdown syntax. it seems
  to have good support from OSS community.